### PR TITLE
fix: #18 exit status "2" after syntax error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: athonda <athonda@student.42singapore.sg    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/06/15 14:23:26 by xlok              #+#    #+#              #
-#    Updated: 2024/11/15 22:01:51 by xlok             ###   ########.fr        #
+#    Updated: 2024/11/16 19:59:40 by athonda          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -41,6 +41,7 @@ SRC_F := minishell.c \
 		 builtin_export.c \
 		 builtin_export_helper.c \
 		 builtin_unset.c \
+		 long_check.c \
 		 builtin_exit.c \
 		 tokenize.c \
 		 token.c \

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: athonda <athonda@student.42singapore.sg    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/06 19:34:03 by xlok              #+#    #+#             */
-/*   Updated: 2024/11/15 22:02:41 by xlok             ###   ########.fr       */
+/*   Updated: 2024/11/16 21:34:06 by athonda          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,7 @@
 # include <stdbool.h>
 # include <signal.h>
 # include <errno.h>
+# include <limits.h>
 # include "libft.h"
 
 # define READ O_RDONLY
@@ -161,6 +162,8 @@ void	builtin_pwd(t_ms *ms);
 void	builtin_env(t_ms *ms);
 void	builtin_export(t_ms *ms);
 void	builtin_unset(t_ms *ms);
+void	clean_before_exit(t_ms *ms, unsigned char c);
+void	long_check(t_ms *ms);
 void	builtin_exit(t_ms *ms);
 int		display_if_no_arg(t_ms *ms);
 void	export_add(t_ms *ms, t_envp **envp);

--- a/src/builtin_exit.c
+++ b/src/builtin_exit.c
@@ -6,7 +6,7 @@
 /*   By: athonda <athonda@student.42singapore.sg    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/01 21:58:55 by athonda           #+#    #+#             */
-/*   Updated: 2024/11/16 22:33:52 by athonda          ###   ########.fr       */
+/*   Updated: 2024/11/16 22:47:38 by athonda          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,7 +72,7 @@ static void	process_arg(t_ms *ms)
 			ft_dprintf(2, "exit\n");
 			ft_dprintf(2, "bash: exit: %s: numeric argument required\n", \
 			ms->cmd[1]);
-			clean_before_exit(ms, 2);
+			clean_cmd_before_exit(ms, 2);
 		}
 		i++;
 	}

--- a/src/builtin_exit.c
+++ b/src/builtin_exit.c
@@ -6,7 +6,7 @@
 /*   By: athonda <athonda@student.42singapore.sg    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/01 21:58:55 by athonda           #+#    #+#             */
-/*   Updated: 2024/11/16 16:19:14 by xlok             ###   ########.fr       */
+/*   Updated: 2024/11/16 22:11:27 by athonda          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,7 +27,7 @@
  *		- exit number and one more arguments
  */
 
-static void	clean_before_exit(t_ms *ms, unsigned char c)
+void	clean_before_exit(t_ms *ms, unsigned char c)
 {
 	free(ms->cmd_envp);
 	free_str_array(ms->cmd);
@@ -66,7 +66,7 @@ static void	process_arg(t_ms *ms)
 	i = 0;
 	if (ms->cmd[1] && (ms->cmd[1][i] == '-' || ms->cmd[1][i] == '+'))
 		i++;
-	if (ms->cmd[1] && !ms->cmd[1][1])
+	if (ms->cmd[1] && !ms->cmd[1][i])
 	{
 		ft_dprintf(2, "exit\n");
 		ft_dprintf(2, "bash: exit: %s: numeric argument required\n", ms->cmd[1]);
@@ -77,7 +77,8 @@ static void	process_arg(t_ms *ms)
 		if (!ft_isdigit(ms->cmd[1][i]))
 		{
 			ft_dprintf(2, "exit\n");
-			ft_dprintf(2, "bash: exit: %s: numeric argument required\n", ms->cmd[1]);
+			ft_dprintf(2, "bash: exit: %s: numeric argument required\n", \
+			ms->cmd[1]);
 			clean_before_exit(ms, 2);
 		}
 		i++;
@@ -89,6 +90,7 @@ void	builtin_exit(t_ms *ms)
 	unsigned char	c;
 
 	process_arg(ms);
+	long_check(ms);
 	if (ms->cmd[1])
 		c = ft_atoi(ms->cmd[1]);
 	else

--- a/src/long_check.c
+++ b/src/long_check.c
@@ -1,0 +1,57 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   long_check.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: xlok <xlok@student.42singapore.sg>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/19 18:23:05 by xlok              #+#    #+#             */
+/*   Updated: 2024/11/16 22:07:53 by athonda          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+void	display_numeric_error(t_ms *ms, unsigned long res, int sign)
+{
+	if (sign == 1 && (res > LONG_MAX))
+	{
+		ft_dprintf(2, "exit\n");
+		ft_dprintf(2, "bash: exit: %s: numeric argument required\n", ms->cmd[1]);
+		clean_before_exit(ms, 2);
+	}
+	else if (sign == -1 && (res - 1 > LONG_MAX))
+	{
+		ft_dprintf(2, "exit\n");
+		ft_dprintf(2, "bash: exit: %s: numeric argument required\n", ms->cmd[1]);
+		clean_before_exit(ms, 2);
+	}
+}
+
+void	long_check(t_ms *ms)
+{
+	unsigned long	res;
+	int				sign;
+	int				i;
+
+	i = 0;
+	sign = 1;
+	if (ms->cmd[1][i] == '-')
+		sign = -1;
+	if (ms->cmd[1][i] == '+' || ms->cmd[1][i] == '-')
+		i++;
+	if ((i == 0 && ft_strlen(ms->cmd[1]) > 19) || \
+		(i == 1 && ft_strlen(ms->cmd[1]) > 20))
+	{
+		ft_dprintf(2, "exit\n");
+		ft_dprintf(2, "bash: exit: %s: numeric argument required\n", ms->cmd[1]);
+		clean_before_exit(ms, 2);
+	}
+	res = 0;
+	while (ms->cmd[1][i] >= '0' && ms->cmd[1][i] <= '9')
+	{
+		res = (res * 10) + (ms->cmd[1][i] - '0');
+		display_numeric_error(ms, res, sign);
+		i++;
+	}
+}

--- a/src/long_check.c
+++ b/src/long_check.c
@@ -6,7 +6,7 @@
 /*   By: xlok <xlok@student.42singapore.sg>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/19 18:23:05 by xlok              #+#    #+#             */
-/*   Updated: 2024/11/16 22:07:53 by athonda          ###   ########.fr       */
+/*   Updated: 2024/11/16 22:50:04 by athonda          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,13 +18,13 @@ void	display_numeric_error(t_ms *ms, unsigned long res, int sign)
 	{
 		ft_dprintf(2, "exit\n");
 		ft_dprintf(2, "bash: exit: %s: numeric argument required\n", ms->cmd[1]);
-		clean_before_exit(ms, 2);
+		clean_cmd_before_exit(ms, 2);
 	}
 	else if (sign == -1 && (res - 1 > LONG_MAX))
 	{
 		ft_dprintf(2, "exit\n");
 		ft_dprintf(2, "bash: exit: %s: numeric argument required\n", ms->cmd[1]);
-		clean_before_exit(ms, 2);
+		clean_cmd_before_exit(ms, 2);
 	}
 }
 
@@ -45,7 +45,7 @@ void	long_check(t_ms *ms)
 	{
 		ft_dprintf(2, "exit\n");
 		ft_dprintf(2, "bash: exit: %s: numeric argument required\n", ms->cmd[1]);
-		clean_before_exit(ms, 2);
+		clean_cmd_before_exit(ms, 2);
 	}
 	res = 0;
 	while (ms->cmd[1][i] >= '0' && ms->cmd[1][i] <= '9')

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: athonda <athonda@student.42singapore.sg    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/14 19:45:28 by xlok              #+#    #+#             */
-/*   Updated: 2024/11/15 10:59:18 by xlok             ###   ########.fr       */
+/*   Updated: 2024/11/16 17:26:02 by athonda          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,8 @@ static void	process_flow(t_ms *ms)
 	if (ms->error)
 		return ;
 	ms->start_node = parser(&ms->head);
+	if (!ms->start_node)
+		ms->exit_status = 2;
 	if (g_sig)
 		ms->exit_status = 128 + g_sig;
 	else

--- a/src/syntax_checker.c
+++ b/src/syntax_checker.c
@@ -6,7 +6,7 @@
 /*   By: athonda <athonda@student.42singapore.sg    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/24 22:12:57 by xlok              #+#    #+#             */
-/*   Updated: 2024/11/15 10:51:57 by athonda          ###   ########.fr       */
+/*   Updated: 2024/11/16 17:32:20 by athonda          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,6 +67,9 @@ int	syntax_check_parenthesis(char *str)
 int	syntax_checker(t_ms *ms, char *str)
 {
 	if (syntax_check_quote(str) || syntax_check_parenthesis(str))
+	{
 		ms->error = true;
+		ms->exit_status = 2;
+	}
 	return (ms->error);
 }


### PR DESCRIPTION
 1. syntax_checker: assign 2 to ms->exit_status
 2. process_flow: assign 2 after parsing with return NULL